### PR TITLE
Custom Enemy Speed ABI V2

### DIFF
--- a/ModCommon/Components/InfiniteEnemy.cs
+++ b/ModCommon/Components/InfiniteEnemy.cs
@@ -115,7 +115,7 @@ namespace ModCommon
             {
                 dance = maxDanceSpeed;
             }
-            updateDanceSpeed(dance);
+            UpdateDanceSpeed(dance);
         }
         
         

--- a/ModCommon/Util/FsmUtil.cs
+++ b/ModCommon/Util/FsmUtil.cs
@@ -77,6 +77,8 @@ namespace ModCommon.Util
 
         public static FsmStateAction GetAction(PlayMakerFSM fsm, string stateName, int index)
         {
+            if (fsm == null)
+                return null;
             foreach (FsmState t in fsm.FsmStates)
             {
                 if (t.Name != stateName) continue;


### PR DESCRIPTION
Adds greatly increased versitility by letting the user update the speed of OTHER gameobjects, as well as the speed of a setvelocity2d. Also you can update a custom index if you know what the index is. Finally, FSM actions are now cached inside the struct. This is possible thanks to the new struct constructors which make much more sense than assigning struct values by hand (which you can still do).

There is only one breakage and that was the rename of updateDanceSpeed to UpdateDanceSpeed to fit the naming conventions of ModCommon.

Also FsmUtil GetAction was modified to not break if the fsm you pass it is null.